### PR TITLE
navbar-marge-on-scroll-fixed

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -43,7 +43,7 @@ body, html{
   top: 0;
   left: 0;
   width: 100%;
-  z-index: 10000;
+  z-index: 100000;
   padding: 0.3em 3em;
 }
 
@@ -1169,19 +1169,22 @@ Clear form styling........
 
 /*The upper porsion of the form was covered by black layer,so to remove that i made resume-form and form header render on top of that layer....   */
 
+
 #resume-form {
   position: relative; 
-  z-index: 9999; 
+  z-index: 100; 
   background: white; 
 }
 
 .form-header {
   position: relative;
-  z-index: 10000; 
+  z-index: 100; 
   background: white; 
   padding: 10px; 
   width: 100%; 
 }
+
+
 
 
 


### PR DESCRIPTION
# Pull Request Template

## Description

while the individual form scrolls perfectly underneath the nav bar, but while scrolling the entire page the form gets over the nav bar at the very last moment, i get it fixed . Please check it out.

Fixes # (issue) : #94 

## Screenshots (if applicable) : 

PREVIOUSLY.......................................

![Screenshot (299)](https://github.com/user-attachments/assets/43e46ca9-0eae-4f3d-962f-5894c4f18839)


AFTER THE CORRECTION : 

![Screenshot (300)](https://github.com/user-attachments/assets/d08a9493-8fa0-4dcd-9d15-8bad87da221b)



## How Has This Been Tested?

I have manually tested, and gave the screen shot of the results , this addition doesn't alter any feature other then the desired.


## Checklist

<!-- Check all the items that apply. -->
- [YES ] My code follows the style guidelines of this project.
- [ SURE] I have performed a self-review of my code.
- [YES ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ YES ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
