### PR TITLE
Minor changes in resume preview box position

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -63,6 +63,7 @@ body, html{
   width: 100%;
   z-index: 100000;
   padding: 0.3em 3em;
+  margin-bottom: 2px;
 }
 
 .navbar .logo {
@@ -217,6 +218,8 @@ input:focus, textarea:focus {
 }
 
 .preview-container {
+  position: relative;
+  top:32px ;
   background: #e8f5e9; 
   border-radius: 10px;
   padding: 20px;


### PR DESCRIPTION
iSSUE NO- #138 

Previously the Preview box was merging with the Navbar, which doen't look very estheatic.

changes:

Gave proper spacing between resume preview and navbar and made sure the form and the preview box align perfectly.

PREVIOUSLY :
![Screenshot (336)](https://github.com/user-attachments/assets/b0848183-7c58-4c43-9bf7-11644747eeff)


AFTER THE MINOR CHANGES..................................

![Screenshot (337)](https://github.com/user-attachments/assets/ee573c3d-336f-4a1a-93d6-fc7662d7a702)
![Screenshot (335)](https://github.com/user-attachments/assets/2ec070f2-4d37-419f-af8c-2b4ddcbc1c2d)
